### PR TITLE
Remove set log level statement.

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -26,7 +26,6 @@ from einops import rearrange, repeat
 import torch.distributed as dist
 from torchvision import datasets, transforms, utils
 
-logging.getLogger().setLevel(logging.WARNING)
 simplefilter(action='ignore', category=FutureWarning)
 
 def get_logger(filename=None):


### PR DESCRIPTION
ComfyUI now uses the logging package and sets the log level itself. Changing it on the root logger disables useful prints, like custom node loading times.